### PR TITLE
Cache Node Modules

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,13 +12,9 @@ jobs:
         uses: actions/checkout@v3.3.0
 
       - name: Cache dependencies
-        uses: actions/cache@v3.2.5
+        uses: auguwu/node-pm-action@v1.0.1
         with:
-          path: node_modules
-          key: node-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
-
-      - name: Install dependencies
-        run: npm install
+          package-manager: npm
 
       - name: Run formatter
         run: npm run format
@@ -37,13 +33,9 @@ jobs:
         uses: actions/checkout@v3.3.0
 
       - name: Cache dependencies
-        uses: actions/cache@v3.2.5
+        uses: auguwu/node-pm-action@v1.0.1
         with:
-          path: node_modules
-          key: node-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
-
-      - name: Install dependencies
-        run: npm install
+          package-manager: npm
 
       - name: Run unit tests
         run: npm test
@@ -55,13 +47,9 @@ jobs:
         uses: actions/checkout@v3.3.0
 
       - name: Cache dependencies
-        uses: actions/cache@v3.2.5
+        uses: auguwu/node-pm-action@v1.0.1
         with:
-          path: node_modules
-          key: node-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
-
-      - name: Install dependencies
-        run: npm install
+          package-manager: npm
 
       - name: Run static analysis
         run: npm run lint
@@ -74,13 +62,9 @@ jobs:
         uses: actions/checkout@v3.3.0
 
       - name: Cache dependencies
-        uses: actions/cache@v3.2.5
+        uses: auguwu/node-pm-action@v1.0.1
         with:
-          path: node_modules
-          key: node-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
-
-      - name: Install dependencies
-        run: npm install
+          package-manager: npm
 
       - name: Build this project
         run: npm run build


### PR DESCRIPTION
Use [Node Package Manager Cache](https://github.com/marketplace/actions/node-package-manager-cache) to cache `node_modules` and automatically install [npm](https://www.npmjs.com) dependencies.