### PR TITLE
Log Package: Use `exec.Command`

### DIFF
--- a/packages/log/src/group.test.ts
+++ b/packages/log/src/group.test.ts
@@ -3,6 +3,8 @@ import { beforeAll, describe, expect, test } from "@jest/globals";
 import { group } from "./group";
 import { info } from "./log";
 
+const node = new exec.Command("node", "-e");
+
 describe("group output of an async function", () => {
   describe("on a successful function", () => {
     test("should be resolved", () => {
@@ -16,14 +18,13 @@ describe("group output of an async function", () => {
     describe("runs in a separate process", () => {
       let prom: Promise<exec.Result>;
       test("should be resolved", () => {
-        const code = [
-          "const log = require('./packages/log/lib');",
-          "log.group('some group', async () => {",
-          "  log.info('some info');",
-          "  return true;",
-          "});",
-        ].join("\n");
-        prom = exec.execOut("node", "-e", code);
+        prom = node.execOut(
+          "const log = require('./packages/log/lib');\n\
+          log.group('some group', async () => {\n\
+            log.info('some info')\n\
+            return true;\n\
+          });"
+        );
         return expect(prom).resolves.toBeTruthy();
       });
       describe("checks output", () => {
@@ -60,14 +61,13 @@ describe("group output of an async function", () => {
     describe("runs in a separate process", () => {
       let prom: Promise<exec.Result>;
       test("should be resolved", () => {
-        const code = [
-          "const log = require('./packages/log/lib');",
-          "log.group('some group', async () => {",
-          "  log.info('some info');",
-          "  throw new Error('some error');",
-          "}).catch((err) => {});",
-        ].join("\n");
-        prom = exec.execOut("node", "-e", code);
+        prom = node.execOut(
+          "const log = require('./packages/log/lib');\n\
+          log.group('some group', async () => {\n\
+            log.info('some info');\n\
+            throw new Error('some error');\n\
+          }).catch((err) => {});"
+        );
         return expect(prom).resolves.toBeTruthy();
       });
       describe("checks output", () => {

--- a/packages/log/src/log.test.ts
+++ b/packages/log/src/log.test.ts
@@ -2,6 +2,8 @@ import * as exec from "@actions-kit/exec";
 import { beforeAll, describe, expect, test } from "@jest/globals";
 import { error, fatal, warning } from "./log";
 
+const node = new exec.Command("node", "-e");
+
 describe("writes warning to log", () => {
   test("should not throw", () => {
     expect(() => warning("some message")).not.toThrow();
@@ -9,11 +11,10 @@ describe("writes warning to log", () => {
   describe("runs in a separate process", () => {
     let prom: Promise<exec.Result>;
     test("should be resolved", () => {
-      const code = [
-        "const log = require('./packages/log/lib');",
-        "log.warning('some message');",
-      ].join("\n");
-      prom = exec.execOut("node", "-e", code);
+      prom = node.execOut(
+        "const log = require('./packages/log/lib');\n\
+        log.warning('some message');"
+      );
       return expect(prom).resolves.toBeTruthy();
     });
     describe("checks output", () => {
@@ -36,11 +37,10 @@ describe("writes error to log", () => {
   describe("runs in a separate process", () => {
     let prom: Promise<exec.Result>;
     test("should be resolved", () => {
-      const code = [
-        "const log = require('./packages/log/lib');",
-        "log.error('some message');",
-      ].join("\n");
-      prom = exec.execOut("node", "-e", code);
+      prom = node.execOut(
+        "const log = require('./packages/log/lib');\n\
+        log.error('some message');"
+      );
       return expect(prom).resolves.toBeTruthy();
     });
     describe("checks output", () => {
@@ -63,11 +63,10 @@ describe("writes a fatal message to the log", () => {
   describe("runs in a separate process", () => {
     let prom: Promise<exec.Result>;
     test("should be resolved", () => {
-      const code = [
-        "const log = require('./packages/log/lib');",
-        "log.fatal('some message');",
-      ].join("\n");
-      prom = exec.execOut("node", "-e", code);
+      prom = node.execOut(
+        "const log = require('./packages/log/lib');\n\
+        log.fatal('some message');"
+      );
       return expect(prom).resolves.toBeTruthy();
     });
     describe("checks the output and the status", () => {


### PR DESCRIPTION
Use `Command.execOut` method in replacement of just using the `execOut`.