### PR TITLE
Specify Jest Option in the Config File

### DIFF
--- a/internal/dev/package.json
+++ b/internal/dev/package.json
@@ -37,6 +37,7 @@
     "eslint-plugin-github": "^4.6.1",
     "eslint-plugin-jest": "^27.2.1",
     "jest": "^29.4.3",
+    "jest-serial-runner": "^1.2.1",
     "jsonfile": "^6.1.0",
     "prettier": "^2.8.4",
     "ts-jest": "^29.0.5",

--- a/internal/dev/src/jest.ts
+++ b/internal/dev/src/jest.ts
@@ -14,6 +14,7 @@ export function jestConfig(config?: Config): Config {
       },
     },
     moduleFileExtensions: ["js", "ts"],
+    runner: "jest-serial-runner",
     testEnvironment: "node",
     testMatch: ["**/*.test.ts"],
     transform: {

--- a/internal/dev/src/jest.ts
+++ b/internal/dev/src/jest.ts
@@ -3,6 +3,7 @@ import { Config } from "jest";
 export function jestConfig(config?: Config): Config {
   return {
     clearMocks: true,
+    collectCoverage: true,
     coveragePathIgnorePatterns: ["/lib/"],
     coverageThreshold: {
       global: {

--- a/packages/envi/package.json
+++ b/packages/envi/package.json
@@ -15,7 +15,7 @@
     "build": "rm -rf lib && tsc",
     "format": "prettier --write \"*.{js,ts,json}\" \"src/**/*.ts\"",
     "lint": "eslint src --ext .js,.ts",
-    "test": "jest --coverage --runInBand"
+    "test": "jest --runInBand"
   },
   "dependencies": {
     "@actions/core": "^1.10.0"

--- a/packages/envi/package.json
+++ b/packages/envi/package.json
@@ -15,7 +15,7 @@
     "build": "rm -rf lib && tsc",
     "format": "prettier --write \"*.{js,ts,json}\" \"src/**/*.ts\"",
     "lint": "eslint src --ext .js,.ts",
-    "test": "jest --runInBand"
+    "test": "jest"
   },
   "dependencies": {
     "@actions/core": "^1.10.0"

--- a/packages/exec/package.json
+++ b/packages/exec/package.json
@@ -28,7 +28,7 @@
     "build": "rm -rf lib && tsc",
     "format": "prettier --write \"*.{js,ts,json}\" \"src/**/*.ts\"",
     "lint": "eslint src --ext .js,.ts",
-    "test": "jest --runInBand"
+    "test": "jest"
   },
   "dependencies": {
     "@actions/exec": "^1.1.1"

--- a/packages/exec/package.json
+++ b/packages/exec/package.json
@@ -28,7 +28,7 @@
     "build": "rm -rf lib && tsc",
     "format": "prettier --write \"*.{js,ts,json}\" \"src/**/*.ts\"",
     "lint": "eslint src --ext .js,.ts",
-    "test": "jest --coverage --runInBand"
+    "test": "jest --runInBand"
   },
   "dependencies": {
     "@actions/exec": "^1.1.1"

--- a/packages/log/package.json
+++ b/packages/log/package.json
@@ -20,7 +20,7 @@
     "build": "rm -rf lib && tsc",
     "format": "prettier --write \"*.{js,ts,json}\" \"src/**/*.ts\"",
     "lint": "eslint src --ext .js,.ts",
-    "test": "jest --coverage --runInBand"
+    "test": "jest --runInBand"
   },
   "dependencies": {
     "@actions/core": "^1.10.0"

--- a/packages/log/package.json
+++ b/packages/log/package.json
@@ -20,7 +20,7 @@
     "build": "rm -rf lib && tsc",
     "format": "prettier --write \"*.{js,ts,json}\" \"src/**/*.ts\"",
     "lint": "eslint src --ext .js,.ts",
-    "test": "jest --runInBand"
+    "test": "jest"
   },
   "dependencies": {
     "@actions/core": "^1.10.0"

--- a/packages/pip/package.json
+++ b/packages/pip/package.json
@@ -28,7 +28,7 @@
     "build": "rm -rf lib && tsc",
     "format": "prettier --write \"*.{js,ts,json}\" \"src/**/*.ts\"",
     "lint": "eslint src --ext .js,.ts",
-    "test": "jest --runInBand"
+    "test": "jest"
   },
   "dependencies": {
     "@actions-kit/exec": "^0.2.0",

--- a/packages/pip/package.json
+++ b/packages/pip/package.json
@@ -28,7 +28,7 @@
     "build": "rm -rf lib && tsc",
     "format": "prettier --write \"*.{js,ts,json}\" \"src/**/*.ts\"",
     "lint": "eslint src --ext .js,.ts",
-    "test": "jest --coverage --runInBand"
+    "test": "jest --runInBand"
   },
   "dependencies": {
     "@actions-kit/exec": "^0.2.0",


### PR DESCRIPTION
Change `--coverage` and `--runInBand` options of [Jest](https://jestjs.io/) to be specified in the config files instead.