### PR TITLE
Workflows on Pull Request Exclude Latest Branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: build
 on:
   workflow_dispatch:
   pull_request:
+    branches: ["*", "!*@latest"]
   push:
     branches: [main]
 jobs:


### PR DESCRIPTION
Change pull request events to only trigger `build.yml` workflow only if that pull request is targeting any branches except latest branch of each packages (`*@latest`). 