### PR TITLE
Fix Nx Targets Dependencies

### DIFF
--- a/internal/dev/package.json
+++ b/internal/dev/package.json
@@ -28,9 +28,10 @@
     "directory": "internal/dev"
   },
   "scripts": {
-    "build": "rm -rf lib && tsc",
+    "build": "tsc",
     "format": "prettier --write \"*.{js,json}\" \"src/**/*.ts\"",
-    "lint": "tsc && eslint src --ext .js,.ts"
+    "lint": "tsc && eslint src --ext .js,.ts",
+    "test": "tsc"
   },
   "devDependencies": {
     "eslint": "^8.34.0",

--- a/nx.json
+++ b/nx.json
@@ -12,13 +12,16 @@
       "dependsOn": ["^format"]
     },
     "lint": {
-      "dependsOn": ["^build", "^lint", "format"]
+      "dependsOn": ["^build", "^lint", "format"],
+      "implicitDependencies": ["@actions-kit/dev"]
     },
     "build": {
-      "dependsOn": ["^build", "lint"]
+      "dependsOn": ["^build", "lint"],
+      "implicitDependencies": ["@actions-kit/dev"]
     },
     "test": {
-      "dependsOn": ["build"]
+      "dependsOn": ["build"],
+      "implicitDependencies": ["@actions-kit/dev"]
     }
   }
 }


### PR DESCRIPTION
Fix [Nx](https://nx.dev/) targets dependencies by make most targets to be implicitly depends on [@actions-kit/dev](https://github.com/threeal/actions-kit/tree/main/internal/dev).