### PR TITLE
Lerna Specify Target Inputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 !.eslint*
 !.git*
 
+*.log
 tsconfig.eslint.json
 
 coverage/

--- a/nx.json
+++ b/nx.json
@@ -16,7 +16,7 @@
   "targetDefaults": {
     "format": {
       "dependsOn": ["^format"],
-      "inputs": ["rootFiles", "sourceFiles"]
+      "inputs": ["eslintConfig", "rootFiles", "sourceFiles"]
     },
     "lint": {
       "dependsOn": ["^build", "^lint", "format"],

--- a/nx.json
+++ b/nx.json
@@ -1,5 +1,8 @@
 {
   "namedInputs": {
+    "eslintConfig": [
+      "{projectRoot}/.eslintrc.js"
+    ],
     "rootFiles": [
       "{projectRoot}/*.js",
       "{projectRoot}/*.ts",
@@ -17,7 +20,8 @@
     },
     "lint": {
       "dependsOn": ["^build", "^lint", "format"],
-      "implicitDependencies": ["@actions-kit/dev"]
+      "implicitDependencies": ["@actions-kit/dev"],
+      "inputs": ["eslintConfig", "sourceFiles"]
     },
     "build": {
       "dependsOn": ["^build", "lint"],

--- a/nx.json
+++ b/nx.json
@@ -1,12 +1,4 @@
 {
-  "tasksRunnerOptions": {
-    "default": {
-      "runner": "nx/tasks-runners/default",
-      "options": {
-        "cacheableOperations": ["build", "format", "lint", "test"]
-      }
-    }
-  },
   "targetDefaults": {
     "format": {
       "dependsOn": ["^format"]
@@ -22,6 +14,14 @@
     "test": {
       "dependsOn": ["build"],
       "implicitDependencies": ["@actions-kit/dev"]
+    }
+  },
+  "tasksRunnerOptions": {
+    "default": {
+      "runner": "nx/tasks-runners/default",
+      "options": {
+        "cacheableOperations": ["build", "format", "lint", "test"]
+      }
     }
   }
 }

--- a/nx.json
+++ b/nx.json
@@ -6,6 +6,9 @@
     "jestConfig": [
       "{projectRoot}/jest.config.ts"
     ],
+    "packageConfig": [
+      "{projectRoot}/package.json"
+    ],
     "rootFiles": [
       "{projectRoot}/*.js",
       "{projectRoot}/*.ts",
@@ -30,6 +33,7 @@
       "dependsOn": ["^format"],
       "inputs": [
         "eslintConfig",
+        "packageConfig",
         "rootFiles",
         "sourceFiles",
         "typescriptConfig"
@@ -40,6 +44,7 @@
       "implicitDependencies": ["@actions-kit/dev"],
       "inputs": [
         "eslintConfig",
+        "packageConfig",
         "sourceFiles"
       ]
     },
@@ -47,6 +52,7 @@
       "dependsOn": ["^build", "lint"],
       "implicitDependencies": ["@actions-kit/dev"],
       "inputs": [
+        "packageConfig",
         "sourceNoTestFiles",
         "typescriptConfig"
       ]
@@ -56,6 +62,7 @@
       "implicitDependencies": ["@actions-kit/dev"],
       "inputs": [
         "jestConfig",
+        "packageConfig",
         "sourceFiles"
       ]
     }

--- a/nx.json
+++ b/nx.json
@@ -11,21 +11,42 @@
     "sourceFiles": [
       "{projectRoot}/src/*.js",
       "{projectRoot}/src/*.ts"
+    ],
+    "sourceOnlyFiles": [
+      "{projectRoot}/src/*.js",
+      "{projectRoot}/src/*.ts",
+      "!{projectRoot}/src/*.test.js",
+      "!{projectRoot}/src/*.test.ts"
+    ],
+    "typescriptConfig": [
+      "{projectRoot}/tsconfig.json"
     ]
   },
   "targetDefaults": {
     "format": {
       "dependsOn": ["^format"],
-      "inputs": ["eslintConfig", "rootFiles", "sourceFiles"]
+      "inputs": [
+        "eslintConfig",
+        "rootFiles",
+        "sourceFiles",
+        "typescriptConfig"
+      ]
     },
     "lint": {
       "dependsOn": ["^build", "^lint", "format"],
       "implicitDependencies": ["@actions-kit/dev"],
-      "inputs": ["eslintConfig", "sourceFiles"]
+      "inputs": [
+        "eslintConfig",
+        "sourceFiles"
+      ]
     },
     "build": {
       "dependsOn": ["^build", "lint"],
-      "implicitDependencies": ["@actions-kit/dev"]
+      "implicitDependencies": ["@actions-kit/dev"],
+      "inputs": [
+        "sourceOnlyFiles",
+        "typescriptConfig"
+      ]
     },
     "test": {
       "dependsOn": ["build"],

--- a/nx.json
+++ b/nx.json
@@ -9,11 +9,6 @@
     "packageConfig": [
       "{projectRoot}/package.json"
     ],
-    "rootFiles": [
-      "{projectRoot}/*.js",
-      "{projectRoot}/*.ts",
-      "{projectRoot}/*.json"
-    ],
     "sourceFiles": [
       "{projectRoot}/src/*.js",
       "{projectRoot}/src/*.ts"
@@ -33,8 +28,8 @@
       "dependsOn": ["^format"],
       "inputs": [
         "eslintConfig",
+        "jestConfig",
         "packageConfig",
-        "rootFiles",
         "sourceFiles",
         "typescriptConfig"
       ]

--- a/nx.json
+++ b/nx.json
@@ -3,6 +3,9 @@
     "eslintConfig": [
       "{projectRoot}/.eslintrc.js"
     ],
+    "jestConfig": [
+      "{projectRoot}/jest.config.ts"
+    ],
     "rootFiles": [
       "{projectRoot}/*.js",
       "{projectRoot}/*.ts",
@@ -12,7 +15,7 @@
       "{projectRoot}/src/*.js",
       "{projectRoot}/src/*.ts"
     ],
-    "sourceOnlyFiles": [
+    "sourceNoTestFiles": [
       "{projectRoot}/src/*.js",
       "{projectRoot}/src/*.ts",
       "!{projectRoot}/src/*.test.js",
@@ -44,13 +47,17 @@
       "dependsOn": ["^build", "lint"],
       "implicitDependencies": ["@actions-kit/dev"],
       "inputs": [
-        "sourceOnlyFiles",
+        "sourceNoTestFiles",
         "typescriptConfig"
       ]
     },
     "test": {
       "dependsOn": ["build"],
-      "implicitDependencies": ["@actions-kit/dev"]
+      "implicitDependencies": ["@actions-kit/dev"],
+      "inputs": [
+        "jestConfig",
+        "sourceFiles"
+      ]
     }
   },
   "tasksRunnerOptions": {

--- a/nx.json
+++ b/nx.json
@@ -1,7 +1,16 @@
 {
+  "namedInputs": {
+    "format": [
+      "{projectRoot}/*.js",
+      "{projectRoot}/*.ts",
+      "{projectRoot}/*.json",
+      "{projectRoot}/src/*.ts"
+    ]
+  },
   "targetDefaults": {
     "format": {
-      "dependsOn": ["^format"]
+      "dependsOn": ["^format"],
+      "inputs": ["format"]
     },
     "lint": {
       "dependsOn": ["^build", "^lint", "format"],

--- a/nx.json
+++ b/nx.json
@@ -1,16 +1,19 @@
 {
   "namedInputs": {
-    "format": [
+    "rootFiles": [
       "{projectRoot}/*.js",
       "{projectRoot}/*.ts",
-      "{projectRoot}/*.json",
+      "{projectRoot}/*.json"
+    ],
+    "sourceFiles": [
+      "{projectRoot}/src/*.js",
       "{projectRoot}/src/*.ts"
     ]
   },
   "targetDefaults": {
     "format": {
       "dependsOn": ["^format"],
-      "inputs": ["format"]
+      "inputs": ["rootFiles", "sourceFiles"]
     },
     "lint": {
       "dependsOn": ["^build", "^lint", "format"],


### PR DESCRIPTION
Specify target inputs in the `nx.json` to make cache of every target to be depended on specific files instead of all files.
Aside from that, this PR also change the `tasRunnerOptions` position in the `nx.json` and ignore `*.log` files from Git.