### PR TITLE
Exec Package: Refactor Jest Mocking

### DIFF
--- a/packages/exec/src/command.test.ts
+++ b/packages/exec/src/command.test.ts
@@ -3,28 +3,26 @@ import { Command } from "./command";
 import { OutputResult } from "./output";
 import { RunResult } from "./run";
 
-jest.mock("./output", () => {
-  const actual = jest.requireActual<object>("./output");
-  const outputCheck = (command: string, ...args: string[]) => {
-    expect(command).toBe("test");
-    const output = args
-      .filter((arg) => !["--success", "--silent"].includes(arg))
-      .join();
-    const code = args.includes("--success") ? 0 : 1;
-    return new OutputResult(code, output);
-  };
-  return {
-    ...actual,
-    output: async (command: string, ...args: string[]) => {
-      expect(args).not.toContain("--silent");
-      return outputCheck(command, ...args);
-    },
-    outputSilently: async (command: string, ...args: string[]) => {
-      expect(args).toContain("--silent");
-      return outputCheck(command, ...args);
-    },
-  };
-});
+function outputCheck(command: string, ...args: string[]) {
+  expect(command).toBe("test");
+  const output = args
+    .filter((arg) => !["--success", "--silent"].includes(arg))
+    .join();
+  const code = args.includes("--success") ? 0 : 1;
+  return new OutputResult(code, output);
+}
+
+jest.mock("./output", () => ({
+  ...jest.requireActual<object>("./output"),
+  output: async (command: string, ...args: string[]) => {
+    expect(args).not.toContain("--silent");
+    return outputCheck(command, ...args);
+  },
+  outputSilently: async (command: string, ...args: string[]) => {
+    expect(args).toContain("--silent");
+    return outputCheck(command, ...args);
+  },
+}));
 
 jest.mock("./run", () => {
   const actual = jest.requireActual<object>("./run");

--- a/packages/exec/src/output.test.ts
+++ b/packages/exec/src/output.test.ts
@@ -2,27 +2,24 @@ import { ExecOptions, ExecOutput } from "@actions/exec";
 import { describe, expect, jest, test } from "@jest/globals";
 import { output, OutputResult, outputSilently } from "./output";
 
-jest.mock("@actions/exec", () => {
-  const actual = jest.requireActual<object>("@actions/exec");
-  return {
-    ...actual,
-    getExecOutput: async (
-      commandLine: string,
-      args: string[],
-      options: ExecOptions
-    ): Promise<ExecOutput> => {
-      expect(commandLine).toBe("test");
-      expect(options.silent).toBe(args.includes("--silent"));
-      return {
-        exitCode: args.includes("--fail") ? 1 : 0,
-        stdout: args
-          .filter((arg) => !["--silent", "--fail"].includes(arg))
-          .join(),
-        stderr: "",
-      };
-    },
-  };
-});
+jest.mock("@actions/exec", () => ({
+  ...jest.requireActual<object>("@actions/exec"),
+  getExecOutput: async (
+    commandLine: string,
+    args: string[],
+    options: ExecOptions
+  ): Promise<ExecOutput> => {
+    expect(commandLine).toBe("test");
+    expect(options.silent).toBe(args.includes("--silent"));
+    return {
+      exitCode: args.includes("--fail") ? 1 : 0,
+      stdout: args
+        .filter((arg) => !["--silent", "--fail"].includes(arg))
+        .join(),
+      stderr: "",
+    };
+  },
+}));
 
 describe("constructs a new command run and output get result", () => {
   test("with a zero status code", () => {

--- a/packages/exec/src/run.test.ts
+++ b/packages/exec/src/run.test.ts
@@ -2,17 +2,14 @@ import { ExecOptions } from "@actions/exec";
 import { describe, expect, jest, test } from "@jest/globals";
 import { run, RunResult, runSilently } from "./run";
 
-jest.mock("@actions/exec", () => {
-  const actual = jest.requireActual<object>("@actions/exec");
-  return {
-    ...actual,
-    exec: async (commandLine: string, args: string[], options: ExecOptions) => {
-      expect(commandLine).toBe("test");
-      expect(options.silent).toBe(args.includes("--silent"));
-      return args.includes("--fail") ? 1 : 0;
-    },
-  };
-});
+jest.mock("@actions/exec", () => ({
+  ...jest.requireActual<object>("@actions/exec"),
+  exec: async (commandLine: string, args: string[], options: ExecOptions) => {
+    expect(commandLine).toBe("test");
+    expect(options.silent).toBe(args.includes("--silent"));
+    return args.includes("--fail") ? 1 : 0;
+  },
+}));
 
 describe("constructs a new command run result", () => {
   test("with a zero status code", () => {


### PR DESCRIPTION
Simplify how to do Jest mocking by directly returns the mocked object in the lambda function call. Somehow like this
```js
// before
() => {
  return {
    // something
  };
};

//after
() => ({
  // something
});
``` 