### PR TITLE
Log Package: Use Jest Mock

### DIFF
--- a/packages/log/package.json
+++ b/packages/log/package.json
@@ -26,7 +26,6 @@
     "@actions/core": "^1.10.0"
   },
   "devDependencies": {
-    "@actions-kit/dev": "^0.1.0",
-    "@actions-kit/exec": "^0.2.0"
+    "@actions-kit/dev": "^0.1.0"
   }
 }

--- a/packages/log/src/emph.test.ts
+++ b/packages/log/src/emph.test.ts
@@ -1,8 +1,6 @@
-import { describe, expect, test } from "@jest/globals";
+import { expect, test } from "@jest/globals";
 import { emph } from "./emph";
 
-describe("emphasizes message", () => {
-  test("message should be written", () => {
-    expect(emph("some message")).toMatch(/some message/);
-  });
+test("emphasizes message", () => {
+  expect(emph("some message")).toMatch(/.+some message.+/);
 });

--- a/packages/log/src/group.test.ts
+++ b/packages/log/src/group.test.ts
@@ -1,9 +1,6 @@
-import * as exec from "@actions-kit/exec";
-import { beforeAll, describe, expect, test } from "@jest/globals";
+import { describe, expect, test } from "@jest/globals";
 import { group } from "./group";
 import { info } from "./log";
-
-const node = new exec.Command("node", "-e");
 
 describe("group output of an async function", () => {
   describe("on a successful function", () => {
@@ -14,39 +11,6 @@ describe("group output of an async function", () => {
       });
       return expect(prom).resolves.toBe(true);
     });
-
-    describe("runs in a separate process", () => {
-      let prom: Promise<exec.OutputResult>;
-      test("should be resolved", () => {
-        prom = node.outputSilently(
-          "const log = require('./lib');\n\
-          log.group('some group', async () => {\n\
-            log.info('some info')\n\
-            return true;\n\
-          });"
-        );
-        return expect(prom).resolves.toBeTruthy();
-      });
-      describe("checks output", () => {
-        let res: exec.OutputResult;
-        beforeAll(async () => (res = await prom));
-        test("group name should be written", () => {
-          expect(res.output).toMatch(/some group/);
-        });
-        test("success info should be written", () => {
-          expect(res.output).toMatch(/Done in \d*(ms|s|m|h)( \d*(ms|s|m))?/);
-        });
-        test("output order should be correct", () => {
-          const groupStartIndex = res.output.indexOf("::group::");
-          const infoIndex = res.output.indexOf("some info");
-          const doneIndex = res.output.indexOf("Done in");
-          const groupEndIndex = res.output.indexOf("::endgroup::");
-          expect(groupStartIndex).toBeLessThan(infoIndex);
-          expect(infoIndex).toBeLessThan(doneIndex);
-          expect(doneIndex).toBeLessThan(groupEndIndex);
-        });
-      });
-    });
   });
 
   describe("on a failed function", () => {
@@ -56,39 +20,6 @@ describe("group output of an async function", () => {
         throw new Error("some error");
       });
       return expect(prom).rejects.toThrow();
-    });
-
-    describe("runs in a separate process", () => {
-      let prom: Promise<exec.OutputResult>;
-      test("should be resolved", () => {
-        prom = node.outputSilently(
-          "const log = require('./lib');\n\
-          log.group('some group', async () => {\n\
-            log.info('some info');\n\
-            throw new Error('some error');\n\
-          }).catch((err) => {});"
-        );
-        return expect(prom).resolves.toBeTruthy();
-      });
-      describe("checks output", () => {
-        let res: exec.OutputResult;
-        beforeAll(async () => (res = await prom));
-        test("group name should be written", () => {
-          expect(res.output).toMatch(/some group/);
-        });
-        test("failure info should be written", () => {
-          expect(res.output).toMatch(/Failed in \d*(ms|s|m|h)( \d*(ms|s|m))?/);
-        });
-        test("output order should be correct", () => {
-          const groupStartIndex = res.output.indexOf("::group::");
-          const infoIndex = res.output.indexOf("some info");
-          const failedIndex = res.output.indexOf("Failed in");
-          const groupEndIndex = res.output.indexOf("::endgroup::");
-          expect(groupStartIndex).toBeLessThan(infoIndex);
-          expect(infoIndex).toBeLessThan(failedIndex);
-          expect(failedIndex).toBeLessThan(groupEndIndex);
-        });
-      });
     });
   });
 });

--- a/packages/log/src/internal/time.test.ts
+++ b/packages/log/src/internal/time.test.ts
@@ -1,14 +1,14 @@
-import { describe, expect, jest, test } from "@jest/globals";
+import { expect, jest, test } from "@jest/globals";
 import { Time } from "./time";
 
-describe("gets current time", () => {
-  test("should be more than zero", () => {
-    expect(Time.now().ms).toBeGreaterThan(0);
-  });
+jest.useFakeTimers();
+
+test("gets current time", () => {
+  jest.setSystemTime(1000);
+  expect(Time.now().ms).toBe(1000);
 });
 
 test("calculates elapsed time", () => {
-  jest.useFakeTimers();
   jest.setSystemTime(1000);
   const time = Time.now();
   jest.setSystemTime(1500);

--- a/packages/log/src/internal/time.test.ts
+++ b/packages/log/src/internal/time.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test } from "@jest/globals";
+import { describe, expect, jest, test } from "@jest/globals";
 import { Time } from "./time";
 
 describe("gets current time", () => {
@@ -7,16 +7,10 @@ describe("gets current time", () => {
   });
 });
 
-describe("calculates elapsed time", () => {
-  let time: Time;
-  beforeEach(async () => (time = Time.now()));
-  test("should be more than the timeout", async () => {
-    await new Promise((r) => setTimeout(r, 50));
-    expect(time.elapsed().ms).toBeGreaterThanOrEqual(50);
-  });
-  test("new one should be more than the old one", async () => {
-    const oldElapsed = time.elapsed();
-    await new Promise((r) => setTimeout(r, 50));
-    expect(time.elapsed().ms).toBeGreaterThan(oldElapsed.ms);
-  });
+test("calculates elapsed time", () => {
+  jest.useFakeTimers();
+  jest.setSystemTime(1000);
+  const time = Time.now();
+  jest.setSystemTime(1500);
+  expect(time.elapsed().ms).toBe(500);
 });

--- a/packages/log/src/log.test.ts
+++ b/packages/log/src/log.test.ts
@@ -1,32 +1,9 @@
-import * as exec from "@actions-kit/exec";
-import { beforeAll, describe, expect, test } from "@jest/globals";
+import { describe, expect, test } from "@jest/globals";
 import { error, fatal, warning } from "./log";
-
-const node = new exec.Command("node", "-e");
 
 describe("writes warning to log", () => {
   test("should not throw", () => {
     expect(() => warning("some message")).not.toThrow();
-  });
-  describe("runs in a separate process", () => {
-    let prom: Promise<exec.OutputResult>;
-    test("should be resolved", () => {
-      prom = node.outputSilently(
-        "const log = require('./lib');\n\
-        log.warning('some message');"
-      );
-      return expect(prom).resolves.toBeTruthy();
-    });
-    describe("checks output", () => {
-      let res: exec.OutputResult;
-      beforeAll(async () => (res = await prom));
-      test("message should be written", () => {
-        expect(res.output).toMatch(/some message/);
-      });
-      test("warning label should be written", () => {
-        expect(res.output).toMatch(/::warning::/);
-      });
-    });
   });
 });
 
@@ -34,53 +11,10 @@ describe("writes error to log", () => {
   test("should not throw", () => {
     expect(() => error("some message")).not.toThrow();
   });
-  describe("runs in a separate process", () => {
-    let prom: Promise<exec.OutputResult>;
-    test("should be resolved", () => {
-      prom = node.outputSilently(
-        "const log = require('./lib');\n\
-        log.error('some message');"
-      );
-      return expect(prom).resolves.toBeTruthy();
-    });
-    describe("checks output", () => {
-      let res: exec.OutputResult;
-      beforeAll(async () => (res = await prom));
-      test("message should be written", () => {
-        expect(res.output).toMatch(/some message/);
-      });
-      test("error label should be written", () => {
-        expect(res.output).toMatch(/::error::/);
-      });
-    });
-  });
 });
 
 describe("writes a fatal message to the log", () => {
   test("should not throws an error", () => {
     expect(() => fatal("some message")).not.toThrow();
-  });
-  describe("runs in a separate process", () => {
-    let prom: Promise<exec.OutputResult>;
-    test("should be resolved", () => {
-      prom = node.outputSilently(
-        "const log = require('./lib');\n\
-        log.fatal('some message');"
-      );
-      return expect(prom).resolves.toBeTruthy();
-    });
-    describe("checks the output and the status", () => {
-      let res: exec.OutputResult;
-      beforeAll(async () => (res = await prom));
-      test("the output should contains the message", () => {
-        expect(res.output).toMatch(/some message/);
-      });
-      test("the output should contains an error label", () => {
-        expect(res.output).toMatch(/::error::/);
-      });
-      test("the status should not be ok", () => {
-        expect(res.isOk()).toBe(false);
-      });
-    });
   });
 });

--- a/packages/log/src/log.test.ts
+++ b/packages/log/src/log.test.ts
@@ -1,20 +1,34 @@
-import { describe, expect, test } from "@jest/globals";
+import { expect, jest, test } from "@jest/globals";
 import { error, fatal, warning } from "./log";
 
-describe("writes warning to log", () => {
-  test("should not throw", () => {
-    expect(() => warning("some message")).not.toThrow();
-  });
+let warningOut = "";
+let errorOut = "";
+let setFailedOut = "";
+
+jest.mock("@actions/core", () => ({
+  ...jest.requireActual<object>("@actions/core"),
+  warning: (message: string) => {
+    warningOut = message;
+  },
+  error: (message: string) => {
+    errorOut = message;
+  },
+  setFailed: (message: string) => {
+    setFailedOut = message;
+  },
+}));
+
+test("writes a warning message to log", () => {
+  warning("some warning message");
+  expect(warningOut).toBe("some warning message");
 });
 
-describe("writes error to log", () => {
-  test("should not throw", () => {
-    expect(() => error("some message")).not.toThrow();
-  });
+test("writes an error message to log", () => {
+  error("some error message");
+  expect(errorOut).toBe("some error message");
 });
 
-describe("writes a fatal message to the log", () => {
-  test("should not throws an error", () => {
-    expect(() => fatal("some message")).not.toThrow();
-  });
+test("writes a fatal message to log", () => {
+  fatal("some fatal message");
+  expect(setFailedOut).toBe("some fatal message");
 });


### PR DESCRIPTION
Use Jest mock and fake timers for testing stuffs in the Log Package.
This PR also remove testing that run function in a separate process and simplify other testing structure.