### PR TITLE
Lerna Fix Wildcard of Source Files Inputs

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -10,14 +10,14 @@
       "{projectRoot}/package.json"
     ],
     "sourceFiles": [
-      "{projectRoot}/src/*.js",
-      "{projectRoot}/src/*.ts"
+      "{projectRoot}/src/**/*.js",
+      "{projectRoot}/src/**/*.ts"
     ],
     "sourceNoTestFiles": [
-      "{projectRoot}/src/*.js",
-      "{projectRoot}/src/*.ts",
-      "!{projectRoot}/src/*.test.js",
-      "!{projectRoot}/src/*.test.ts"
+      "{projectRoot}/src/**/*.js",
+      "{projectRoot}/src/**/*.ts",
+      "!{projectRoot}/src/**/*.test.js",
+      "!{projectRoot}/src/**/*.test.ts"
     ],
     "typescriptConfig": [
       "{projectRoot}/tsconfig.json"


### PR DESCRIPTION
Fix wildcard of source files inputs (`sourceFiles` and `sourceNoTestFiles`) in the `nx.json` file that caused cache does not be recalculated when there are changes in files inside a sub directory.