### PR TITLE
Modify Targets Flow in Lerna

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,11 +34,15 @@ jobs:
 
       - name: Build and test
         if: github.event_name != 'pull_request'
-        run: npm test
+        run: |
+          npm run clean
+          npm test
 
       - name: Build and test since target branch
         if: github.event_name == 'pull_request'
-        run: npm test -- "--since=origin/${{ github.base_ref }}"
+        run: |
+          npm run clean -- "--since=origin/${{ github.base_ref }}"
+          npm test -- "--since=origin/${{ github.base_ref }}"
 
       - name: Check diff
         run: git diff --exit-code HEAD

--- a/nx.json
+++ b/nx.json
@@ -35,7 +35,6 @@
     },
     "lint": {
       "dependsOn": ["^build", "format"],
-      "implicitDependencies": ["@actions-kit/dev"],
       "inputs": [
         "eslintConfig",
         "packageConfig",
@@ -44,7 +43,6 @@
     },
     "build": {
       "dependsOn": ["^build", "lint"],
-      "implicitDependencies": ["@actions-kit/dev"],
       "inputs": [
         "packageConfig",
         "sourceNoTestFiles",
@@ -53,7 +51,6 @@
     },
     "test": {
       "dependsOn": ["^build", "build"],
-      "implicitDependencies": ["@actions-kit/dev"],
       "inputs": [
         "jestConfig",
         "packageConfig",

--- a/nx.json
+++ b/nx.json
@@ -25,7 +25,6 @@
   },
   "targetDefaults": {
     "format": {
-      "dependsOn": ["^format"],
       "inputs": [
         "eslintConfig",
         "jestConfig",
@@ -35,7 +34,7 @@
       ]
     },
     "lint": {
-      "dependsOn": ["^build", "^lint", "format"],
+      "dependsOn": ["^build", "format"],
       "implicitDependencies": ["@actions-kit/dev"],
       "inputs": [
         "eslintConfig",
@@ -53,7 +52,7 @@
       ]
     },
     "test": {
-      "dependsOn": ["build"],
+      "dependsOn": ["^build", "build"],
       "implicitDependencies": ["@actions-kit/dev"],
       "inputs": [
         "jestConfig",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "bootstrap": "npx lerna bootstrap --hoist",
     "build": "lerna run build",
+    "clean": "lerna run clean",
     "format": "lerna run format",
     "lint": "lerna run lint",
     "test": "lerna run test"

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -25,7 +25,8 @@
     "directory": "packages/cache"
   },
   "scripts": {
-    "build": "rimraf lib && tsc",
+    "build": "tsc",
+    "clean": "rimraf lib",
     "format": "prettier --write \"*.{js,ts,json}\" \"src/**/*.ts\"",
     "lint": "eslint src --ext .ts",
     "test": "jest"

--- a/packages/dev/package.json
+++ b/packages/dev/package.json
@@ -29,6 +29,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "clean": "rimraf lib",
     "format": "prettier --write \"*.{js,json}\" \"src/**/*.ts\"",
     "lint": "tsc && eslint src --ext .js,.ts",
     "test": "tsc"

--- a/packages/dev/package.json
+++ b/packages/dev/package.json
@@ -31,8 +31,7 @@
     "build": "tsc",
     "clean": "rimraf lib",
     "format": "prettier --write \"*.{js,json}\" \"src/**/*.ts\"",
-    "lint": "tsc && eslint src --ext .js,.ts",
-    "test": "tsc"
+    "lint": "tsc && eslint src --ext .js,.ts"
   },
   "dependencies": {
     "eslint": "^8.34.0",

--- a/packages/envi/package.json
+++ b/packages/envi/package.json
@@ -26,7 +26,8 @@
     "directory": "packages/envi"
   },
   "scripts": {
-    "build": "rimraf lib && tsc",
+    "build": "tsc",
+    "clean": "rimraf lib",
     "format": "prettier --write \"*.{js,ts,json}\" \"src/**/*.ts\"",
     "lint": "eslint src --ext .js,.ts",
     "test": "jest"

--- a/packages/exec/package.json
+++ b/packages/exec/package.json
@@ -25,7 +25,8 @@
     "directory": "packages/exec"
   },
   "scripts": {
-    "build": "rimraf lib && tsc",
+    "build": "tsc",
+    "clean": "rimraf lib",
     "format": "prettier --write \"*.{js,ts,json}\" \"src/**/*.ts\"",
     "lint": "eslint src --ext .js,.ts",
     "test": "jest"

--- a/packages/log/package.json
+++ b/packages/log/package.json
@@ -17,7 +17,8 @@
     "directory": "packages/log"
   },
   "scripts": {
-    "build": "rimraf lib && tsc",
+    "build": "tsc",
+    "clean": "rimraf lib",
     "format": "prettier --write \"*.{js,ts,json}\" \"src/**/*.ts\"",
     "lint": "eslint src --ext .js,.ts",
     "test": "jest"

--- a/packages/pip/package.json
+++ b/packages/pip/package.json
@@ -25,7 +25,8 @@
     "directory": "packages/pip"
   },
   "scripts": {
-    "build": "rimraf lib && tsc",
+    "build": "tsc",
+    "clean": "rimraf lib",
     "format": "prettier --write \"*.{js,ts,json}\" \"src/**/*.ts\"",
     "lint": "eslint src --ext .js,.ts",
     "test": "jest"


### PR DESCRIPTION
- Modify dependencies on most Lerna targets.
- Add a `clean` target in Lerna, extracted from the `build` target.
- Remove dev package from the implicit dependencies of most Lerna targets.