### PR TITLE
Lerna Fix Dependencies for `format` and `lint` Targets

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -50,7 +50,7 @@
       ]
     },
     "test": {
-      "dependsOn": ["^build", "build"],
+      "dependsOn": ["^build", "format", "lint", "build"],
       "inputs": [
         "jestConfig",
         "packageConfig",

--- a/nx.json
+++ b/nx.json
@@ -42,7 +42,7 @@
       ]
     },
     "build": {
-      "dependsOn": ["^build", "lint"],
+      "dependsOn": ["^build", "format", "lint"],
       "inputs": [
         "packageConfig",
         "sourceNoTestFiles",


### PR DESCRIPTION
make `build` target always depends on `format` target and make `test` target always depends on `format` and `lint` targets.