### PR TITLE
Configure Dependabot Versioning Strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,4 @@ updates:
       interval: daily
     commit-message:
       prefix: chore
+    versioning-strategy: increase


### PR DESCRIPTION
This pull request configures the Dependabot versioning strategy to always increment the version when there's a new update.