### PR TITLE
Configure Dependabot's Label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
       interval: daily
     commit-message:
       prefix: chore
+    labels: [chore]
 
   - package-ecosystem: npm
     directory: /
@@ -13,4 +14,5 @@ updates:
       interval: daily
     commit-message:
       prefix: chore
+    labels: [chore]
     versioning-strategy: increase


### PR DESCRIPTION
This pull request configures the Dependabot to use the `chore` label.