### PR TITLE
Add @types/jsonfile in Dev Package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2691,6 +2691,15 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
     },
+    "node_modules/@types/jsonfile": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.4.tgz",
+      "integrity": "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -14282,6 +14291,7 @@
         "dev": "lib/dev.js"
       },
       "devDependencies": {
+        "@types/jsonfile": "6.1.4",
         "chmod-cli": "^1.0.4"
       }
     },

--- a/packages/dev/package.json
+++ b/packages/dev/package.json
@@ -53,6 +53,7 @@
     "typescript": "^5.2.2"
   },
   "devDependencies": {
+    "@types/jsonfile": "6.1.4",
     "chmod-cli": "^1.0.4"
   }
 }


### PR DESCRIPTION
This pull request resolves #272 by adding [@types/jsonfile](https://www.npmjs.com/package/@types/jsonfile) as the dev dependency to the `dev` package.